### PR TITLE
Rename unified_cli.py to cli.py and fix linting issues

### DIFF
--- a/bin/mcp-agentapi
+++ b/bin/mcp-agentapi
@@ -8,7 +8,6 @@ It follows the MCP SDK best practices for executable scripts.
 
 import sys
 import os
-import asyncio
 import logging
 
 # Configure logging
@@ -23,8 +22,8 @@ parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if parent_dir not in sys.path:
     sys.path.insert(0, parent_dir)
 
-# Import the unified CLI module
-from mcp_agentapi.unified_cli import cli_main
+# Import the CLI module
+from mcp_agentapi.cli import cli_main
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dev = [
 ]
 
 [project.scripts]
-mcp-agentapi = "mcp_agentapi.unified_cli:cli_main"
+mcp-agentapi = "mcp_agentapi.cli:cli_main"
 
 [project.urls]
 "Homepage" = "https://github.com/lord-dubious/mcp-agentapi"


### PR DESCRIPTION
This PR renames the `unified_cli.py` file to `cli.py` and fixes various linting issues:

- Removed unused imports
- Fixed import order
- Fixed unused variables
- Added proper parameter naming for unused parameters
- Updated references in `bin/mcp-agentapi` and `pyproject.toml`

This change simplifies the codebase by using a more concise name for the CLI module while maintaining all functionality.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved code clarity and organization in the command-line interface, including renaming unused arguments and consolidating imports.
  - Updated script entry point for the CLI command to reflect internal module changes.
- **Chores**
  - Removed unused dependencies to streamline the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->